### PR TITLE
Adding Trials of Mana 3P Patch to multitapGames

### DIFF
--- a/SNESGameCore.mm
+++ b/SNESGameCore.mm
@@ -510,6 +510,7 @@ static __weak SNESGameCore *_current;
           @"e9334b9e", // Secret of Mana (France) (Rev 1)
           @"b069bb3a", // Secret of Mana (Germany)
           @"b8049e3c", // Seiken Densetsu 2 (Japan)
+          @"80d9ed26", // Seiken Densetsu 3 (Japan) (Fan English Translation v1.01) [3-Player Edition]
           @"d0176b24", // Secret of Mana (USA)
           @"e6b9a402", // Shijou Saikyou no Quiz Ou Ketteisen Super (Japan)
           @"58da330c", // Shin Nihon Pro Wrestling - Chou Senshi in Tokyo Dome - Fantastic Story (Japan)
@@ -582,6 +583,7 @@ static __weak SNESGameCore *_current;
           @"493fdb13", // Top Gear 3000 (Europe)
           @"b9b9df06", // Planet's Champ TG 3000, The (Japan)
           @"a20be998", // Top Gear 3000 (USA)
+          @"f397bd57", // Trials of Mana (USA) [3-Player Edition] (Released 2019)
           @"26a9c3f4", // Turbo Toons (Europe)
           @"ecb8a53a", // Virtual Soccer (Europe)
           @"1d20cac2", // J.League Super Soccer (Japan)


### PR DESCRIPTION
Seiken Densetstu 3 was released in an English Official translation for the first time in 2019 on Nintendo Switch as a part of the Mana Collection called `Trials of Mana`.

Players excited to play this sequel to Secret of Mana expected it to work with 3 players through a multi-tap - but Squaresoft did not add 3 player logic to this game for an unknown reason, even though it features a party of 3 playable characters in real time.

Fans added a 3 player patch for this as soon as possible and so the only way to enjoy 3 player SD3(ToM) is with this patch.

This patch is provided courtesy of Chris Friesen - Send questions/comments to parlance@wafflemind.net

The CRC32 codes for these were pulled from here fantasyanime.com https://www.fantasyanime.com/mana/som2downloads.htm

Thanks so much for your work on OpenEmu so far.
I wish I had enough xcode knowledge to build this core myself so I can test my changes, but I couldn't figure it out unfortunately so I switched to playing Snes9x on PC.
I hope you can merge this soon so others can enjoy this amazing 3 Player experience on Mac :)